### PR TITLE
v0.9.0

### DIFF
--- a/yogo/CHANGELOG.md
+++ b/yogo/CHANGELOG.md
@@ -3,6 +3,43 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.9.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.8.0...v0.9.0) (2021-04-17)
+
+
+### Bug Fixes
+
+* **algolet:** fix type errors ([527a7e6](https://github.com/dawlet-team/dawlet-poc/commit/527a7e611fd6f804c7a713888553b62892dee279))
+* **algolet:** fix white-out on first page render ([254ad20](https://github.com/dawlet-team/dawlet-poc/commit/254ad20c921019de23a2c3cd5873ec1efa55075e))
+* **algolet:** preserve code after eval ([07fdef5](https://github.com/dawlet-team/dawlet-poc/commit/07fdef54c07f054c30d49a6ba9911e88a88f476b))
+* **algolet:** prevent clone from effecting the original ([acec172](https://github.com/dawlet-team/dawlet-poc/commit/acec17211b9f725691452d1dee4e7b774c27be0a))
+* **algolet:** reflect freq in preview score ([062063f](https://github.com/dawlet-team/dawlet-poc/commit/062063fd53f4b90f7a09131f43a870d545d33e68))
+* **deps:** update apollo graphql packages to v2.18.0 ([1e7088c](https://github.com/dawlet-team/dawlet-poc/commit/1e7088c25ad88e59b4a23744255d2c86064c57ab))
+* **deps:** update dependency electron-updater to v4.3.5 ([f87f628](https://github.com/dawlet-team/dawlet-poc/commit/f87f62880f0002bcc4fa4815534c4d59ea29a4a0))
+* **deps:** update dependency jzz-midi-smf to v1.4.0 ([4552823](https://github.com/dawlet-team/dawlet-poc/commit/4552823e270f5edb2f344616e82d0f639501132e))
+* **deps:** update dependency tone to v14.7.58 ([f6033d6](https://github.com/dawlet-team/dawlet-poc/commit/f6033d6156cd06c705cb3ade9ac721f8a5559c2d))
+* **ui:** fix resize problem of sheetmusic ([d64a1b4](https://github.com/dawlet-team/dawlet-poc/commit/d64a1b40bae8c64ad52b1ccc9387fc83fc75eea4))
+* **utils:** resolve type errors by annotations ([668e2b1](https://github.com/dawlet-team/dawlet-poc/commit/668e2b13b06088d3c643138d0a32f168ef5e1539))
+* **utils:** round midi note number ([2282b81](https://github.com/dawlet-team/dawlet-poc/commit/2282b8186a606b7525c4c145530d492f4ca2afae))
+
+
+### Features
+
+* **algolet:** add builder ([c8f954a](https://github.com/dawlet-team/dawlet-poc/commit/c8f954a172a9b3629ef3425d07350485cd42c6e5))
+* **algolet:** add drag handler for main process ([2976e38](https://github.com/dawlet-team/dawlet-poc/commit/2976e38c6b7bdcc32eedcb3094249f83693f3bdb))
+* **algolet:** add span method ([467904d](https://github.com/dawlet-team/dawlet-poc/commit/467904d52e7c8513f16684394e496b3d9df6a9be))
+* **algolet:** apply offsets ([3a41fc0](https://github.com/dawlet-team/dawlet-poc/commit/3a41fc068bb67dc97fd22464bdbe1db191ea7e03))
+* **algolet:** enable add pitch from top to down ([5caf7dd](https://github.com/dawlet-team/dawlet-poc/commit/5caf7ddbd93a69ef708078cd2eee5db117a24141))
+* **algolet:** enable cloning ([85dcb57](https://github.com/dawlet-team/dawlet-poc/commit/85dcb571a3770dd93eb7da7ec51ad87fc473ac3a))
+* **algolet:** enable dnd midi file ([cd8df17](https://github.com/dawlet-team/dawlet-poc/commit/cd8df17707715e01c76f8a48e5e953b4893c002c))
+* **algolet:** enable reflecting octave in preview score ([592c655](https://github.com/dawlet-team/dawlet-poc/commit/592c65506eb9f697a7748ec1a9a3c7090f1809e7))
+* **algolet:** enable repeat ([cee3590](https://github.com/dawlet-team/dawlet-poc/commit/cee3590e3a4ab21219250fd6447b1e52dc6f9f7e))
+* **algolet:** enable showing score after eval ([a96db97](https://github.com/dawlet-team/dawlet-poc/commit/a96db97fdbb9ad4b412e8d38f2957ded1ef4e17f))
+* **algolet:** flash after eval ([c6e6c0c](https://github.com/dawlet-team/dawlet-poc/commit/c6e6c0c1be12299bfe564e98300c11b3e9e8f22b))
+
+
+
+
+
 # [0.8.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.7.0...v0.8.0) (2020-09-10)
 
 

--- a/yogo/dawlets/algolet/CHANGELOG.md
+++ b/yogo/dawlets/algolet/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.9.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.8.0...v0.9.0) (2021-04-17)
+
+
+### Bug Fixes
+
+* **algolet:** fix type errors ([527a7e6](https://github.com/dawlet-team/dawlet-poc/commit/527a7e611fd6f804c7a713888553b62892dee279))
+* **algolet:** fix white-out on first page render ([254ad20](https://github.com/dawlet-team/dawlet-poc/commit/254ad20c921019de23a2c3cd5873ec1efa55075e))
+* **algolet:** preserve code after eval ([07fdef5](https://github.com/dawlet-team/dawlet-poc/commit/07fdef54c07f054c30d49a6ba9911e88a88f476b))
+* **algolet:** prevent clone from effecting the original ([acec172](https://github.com/dawlet-team/dawlet-poc/commit/acec17211b9f725691452d1dee4e7b774c27be0a))
+* **deps:** update dependency electron-updater to v4.3.5 ([f87f628](https://github.com/dawlet-team/dawlet-poc/commit/f87f62880f0002bcc4fa4815534c4d59ea29a4a0))
+
+
+### Features
+
+* **algolet:** add builder ([c8f954a](https://github.com/dawlet-team/dawlet-poc/commit/c8f954a172a9b3629ef3425d07350485cd42c6e5))
+* **algolet:** add drag handler for main process ([2976e38](https://github.com/dawlet-team/dawlet-poc/commit/2976e38c6b7bdcc32eedcb3094249f83693f3bdb))
+* **algolet:** add span method ([467904d](https://github.com/dawlet-team/dawlet-poc/commit/467904d52e7c8513f16684394e496b3d9df6a9be))
+* **algolet:** apply offsets ([3a41fc0](https://github.com/dawlet-team/dawlet-poc/commit/3a41fc068bb67dc97fd22464bdbe1db191ea7e03))
+* **algolet:** enable add pitch from top to down ([5caf7dd](https://github.com/dawlet-team/dawlet-poc/commit/5caf7ddbd93a69ef708078cd2eee5db117a24141))
+* **algolet:** enable cloning ([85dcb57](https://github.com/dawlet-team/dawlet-poc/commit/85dcb571a3770dd93eb7da7ec51ad87fc473ac3a))
+* **algolet:** enable dnd midi file ([cd8df17](https://github.com/dawlet-team/dawlet-poc/commit/cd8df17707715e01c76f8a48e5e953b4893c002c))
+* **algolet:** enable repeat ([cee3590](https://github.com/dawlet-team/dawlet-poc/commit/cee3590e3a4ab21219250fd6447b1e52dc6f9f7e))
+* **algolet:** enable showing score after eval ([a96db97](https://github.com/dawlet-team/dawlet-poc/commit/a96db97fdbb9ad4b412e8d38f2957ded1ef4e17f))
+* **algolet:** flash after eval ([c6e6c0c](https://github.com/dawlet-team/dawlet-poc/commit/c6e6c0c1be12299bfe564e98300c11b3e9e8f22b))
+
+
+
+
+
 # [0.8.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.7.0...v0.8.0) (2020-09-10)
 
 

--- a/yogo/dawlets/algolet/package-lock.json
+++ b/yogo/dawlets/algolet/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dawlet/algolet",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/yogo/dawlets/algolet/package.json
+++ b/yogo/dawlets/algolet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawlet/algolet",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "license": "MIT",
   "author": "Yuichi Yogo",
@@ -39,9 +39,9 @@
   },
   "description": "Algolet lets you write your own custom logic to generate music.",
   "dependencies": {
-    "@dawlet/graphql": "^0.8.0",
-    "@dawlet/ui": "^0.8.0",
-    "@dawlet/utils": "^0.8.0",
+    "@dawlet/graphql": "^0.9.0",
+    "@dawlet/ui": "^0.9.0",
+    "@dawlet/utils": "^0.9.0",
     "apollo-boost": "0.4.9",
     "electron-log": "4.2.4",
     "electron-updater": "4.3.5",

--- a/yogo/dawlets/launcher/CHANGELOG.md
+++ b/yogo/dawlets/launcher/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.9.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.8.0...v0.9.0) (2021-04-17)
+
+
+### Bug Fixes
+
+* **deps:** update dependency electron-updater to v4.3.5 ([f87f628](https://github.com/dawlet-team/dawlet-poc/commit/f87f62880f0002bcc4fa4815534c4d59ea29a4a0))
+
+
+
+
+
 # [0.8.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.7.0...v0.8.0) (2020-09-10)
 
 

--- a/yogo/dawlets/launcher/package-lock.json
+++ b/yogo/dawlets/launcher/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dawlet/launcher",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/yogo/dawlets/launcher/package.json
+++ b/yogo/dawlets/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawlet/launcher",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "license": "MIT",
   "author": "Yuichi Yogo",
@@ -16,8 +16,8 @@
     "watch:renderer": "webpack --mode=development --watch"
   },
   "dependencies": {
-    "@dawlet/engine": "^0.8.0",
-    "@dawlet/utils": "^0.8.0",
+    "@dawlet/engine": "^0.9.0",
+    "@dawlet/utils": "^0.9.0",
     "@material-ui/core": "4.11.0",
     "electron-log": "4.2.4",
     "electron-updater": "4.3.5",

--- a/yogo/dawlets/synthlet/CHANGELOG.md
+++ b/yogo/dawlets/synthlet/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.9.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.8.0...v0.9.0) (2021-04-17)
+
+
+### Bug Fixes
+
+* **deps:** update dependency electron-updater to v4.3.5 ([f87f628](https://github.com/dawlet-team/dawlet-poc/commit/f87f62880f0002bcc4fa4815534c4d59ea29a4a0))
+* **deps:** update dependency tone to v14.7.58 ([f6033d6](https://github.com/dawlet-team/dawlet-poc/commit/f6033d6156cd06c705cb3ade9ac721f8a5559c2d))
+
+
+
+
+
 # [0.8.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.7.0...v0.8.0) (2020-09-10)
 
 

--- a/yogo/dawlets/synthlet/package-lock.json
+++ b/yogo/dawlets/synthlet/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dawlet/synthlet",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/yogo/dawlets/synthlet/package.json
+++ b/yogo/dawlets/synthlet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawlet/synthlet",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "license": "MIT",
   "author": "Yuichi Yogo",
@@ -16,7 +16,7 @@
   },
   "description": "Synthlet provides a simple synthesizer to playback the music. It has a dedicated local transport on its own. ",
   "dependencies": {
-    "@dawlet/utils": "^0.8.0",
+    "@dawlet/utils": "^0.9.0",
     "apollo-boost": "0.4.9",
     "apollo-link-ws": "1.0.20",
     "electron-log": "4.2.4",

--- a/yogo/lerna.json
+++ b/yogo/lerna.json
@@ -3,5 +3,5 @@
     "dawlets/*",
     "packages/*"
   ],
-  "version": "0.8.0"
+  "version": "0.9.0"
 }

--- a/yogo/packages/engine/CHANGELOG.md
+++ b/yogo/packages/engine/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.9.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.8.0...v0.9.0) (2021-04-17)
+
+
+### Bug Fixes
+
+* **deps:** update apollo graphql packages to v2.18.0 ([1e7088c](https://github.com/dawlet-team/dawlet-poc/commit/1e7088c25ad88e59b4a23744255d2c86064c57ab))
+
+
+
+
+
 # [0.8.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.7.0...v0.8.0) (2020-09-10)
 
 

--- a/yogo/packages/engine/package-lock.json
+++ b/yogo/packages/engine/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dawlet/engine",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/yogo/packages/engine/package.json
+++ b/yogo/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawlet/engine",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "license": "MIT",
   "author": "Yuichi Yogo",
@@ -15,7 +15,7 @@
     "generate:docs": "graphdoc -s ./schema.gql -o ../../docs/schema"
   },
   "dependencies": {
-    "@dawlet/factory": "^0.8.0",
+    "@dawlet/factory": "^0.9.0",
     "@types/graphql": "14.5.0",
     "apollo-server": "2.18.0",
     "graphql": "14.7.0",

--- a/yogo/packages/factory/CHANGELOG.md
+++ b/yogo/packages/factory/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.9.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.8.0...v0.9.0) (2021-04-17)
+
+**Note:** Version bump only for package @dawlet/factory
+
+
+
+
+
 # [0.8.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.7.0...v0.8.0) (2020-09-10)
 
 **Note:** Version bump only for package @dawlet/factory

--- a/yogo/packages/factory/package-lock.json
+++ b/yogo/packages/factory/package-lock.json
@@ -1,6 +1,6 @@
 {
       "name": "@dawlet/factory",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "lockfileVersion": 1,
       "requires": true,
       "dependencies": {

--- a/yogo/packages/factory/package.json
+++ b/yogo/packages/factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawlet/factory",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Factory for Dawlet Entities",
   "main": "lib/index.js",
   "scripts": {

--- a/yogo/packages/graphql/CHANGELOG.md
+++ b/yogo/packages/graphql/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.9.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.8.0...v0.9.0) (2021-04-17)
+
+**Note:** Version bump only for package @dawlet/graphql
+
+
+
+
+
 # [0.8.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.7.0...v0.8.0) (2020-09-10)
 
 

--- a/yogo/packages/graphql/package-lock.json
+++ b/yogo/packages/graphql/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dawlet/graphql",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/yogo/packages/graphql/package.json
+++ b/yogo/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawlet/graphql",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/yogo/packages/ui/CHANGELOG.md
+++ b/yogo/packages/ui/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.9.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.8.0...v0.9.0) (2021-04-17)
+
+
+### Bug Fixes
+
+* **ui:** fix resize problem of sheetmusic ([d64a1b4](https://github.com/dawlet-team/dawlet-poc/commit/d64a1b40bae8c64ad52b1ccc9387fc83fc75eea4))
+
+
+
+
+
 # [0.8.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.7.0...v0.8.0) (2020-09-10)
 
 

--- a/yogo/packages/ui/package-lock.json
+++ b/yogo/packages/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dawlet/ui",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/yogo/packages/ui/package.json
+++ b/yogo/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawlet/ui",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "license": "MIT",
   "author": "Yuichi Yogo",
@@ -14,7 +14,7 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
-    "@dawlet/utils": "^0.8.0",
+    "@dawlet/utils": "^0.9.0",
     "opensheetmusicdisplay": "0.8.4",
     "react": "16.13.1",
     "react-dom": "16.13.1"

--- a/yogo/packages/utils/CHANGELOG.md
+++ b/yogo/packages/utils/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.9.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.8.0...v0.9.0) (2021-04-17)
+
+
+### Bug Fixes
+
+* **algolet:** prevent clone from effecting the original ([acec172](https://github.com/dawlet-team/dawlet-poc/commit/acec17211b9f725691452d1dee4e7b774c27be0a))
+* **algolet:** reflect freq in preview score ([062063f](https://github.com/dawlet-team/dawlet-poc/commit/062063fd53f4b90f7a09131f43a870d545d33e68))
+* **deps:** update dependency jzz-midi-smf to v1.4.0 ([4552823](https://github.com/dawlet-team/dawlet-poc/commit/4552823e270f5edb2f344616e82d0f639501132e))
+* **utils:** resolve type errors by annotations ([668e2b1](https://github.com/dawlet-team/dawlet-poc/commit/668e2b13b06088d3c643138d0a32f168ef5e1539))
+* **utils:** round midi note number ([2282b81](https://github.com/dawlet-team/dawlet-poc/commit/2282b8186a606b7525c4c145530d492f4ca2afae))
+
+
+### Features
+
+* **algolet:** add builder ([c8f954a](https://github.com/dawlet-team/dawlet-poc/commit/c8f954a172a9b3629ef3425d07350485cd42c6e5))
+* **algolet:** enable dnd midi file ([cd8df17](https://github.com/dawlet-team/dawlet-poc/commit/cd8df17707715e01c76f8a48e5e953b4893c002c))
+* **algolet:** enable reflecting octave in preview score ([592c655](https://github.com/dawlet-team/dawlet-poc/commit/592c65506eb9f697a7748ec1a9a3c7090f1809e7))
+* **algolet:** enable showing score after eval ([a96db97](https://github.com/dawlet-team/dawlet-poc/commit/a96db97fdbb9ad4b412e8d38f2957ded1ef4e17f))
+
+
+
+
+
 # [0.8.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.7.0...v0.8.0) (2020-09-10)
 
 

--- a/yogo/packages/utils/package-lock.json
+++ b/yogo/packages/utils/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dawlet/utils",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/yogo/packages/utils/package.json
+++ b/yogo/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawlet/utils",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "license": "MIT",
   "author": "Yuichi Yogo",


### PR DESCRIPTION
# [0.9.0](https://github.com/dawlet-team/dawlet-poc/compare/v0.8.0...v0.9.0) (2021-04-17)


### Bug Fixes

* **algolet:** fix type errors ([527a7e6](https://github.com/dawlet-team/dawlet-poc/commit/527a7e611fd6f804c7a713888553b62892dee279))
* **algolet:** fix white-out on first page render ([254ad20](https://github.com/dawlet-team/dawlet-poc/commit/254ad20c921019de23a2c3cd5873ec1efa55075e))
* **algolet:** preserve code after eval ([07fdef5](https://github.com/dawlet-team/dawlet-poc/commit/07fdef54c07f054c30d49a6ba9911e88a88f476b))
* **algolet:** prevent clone from effecting the original ([acec172](https://github.com/dawlet-team/dawlet-poc/commit/acec17211b9f725691452d1dee4e7b774c27be0a))
* **algolet:** reflect freq in preview score ([062063f](https://github.com/dawlet-team/dawlet-poc/commit/062063fd53f4b90f7a09131f43a870d545d33e68))
* **deps:** update apollo graphql packages to v2.18.0 ([1e7088c](https://github.com/dawlet-team/dawlet-poc/commit/1e7088c25ad88e59b4a23744255d2c86064c57ab))
* **deps:** update dependency electron-updater to v4.3.5 ([f87f628](https://github.com/dawlet-team/dawlet-poc/commit/f87f62880f0002bcc4fa4815534c4d59ea29a4a0))
* **deps:** update dependency jzz-midi-smf to v1.4.0 ([4552823](https://github.com/dawlet-team/dawlet-poc/commit/4552823e270f5edb2f344616e82d0f639501132e))
* **deps:** update dependency tone to v14.7.58 ([f6033d6](https://github.com/dawlet-team/dawlet-poc/commit/f6033d6156cd06c705cb3ade9ac721f8a5559c2d))
* **ui:** fix resize problem of sheetmusic ([d64a1b4](https://github.com/dawlet-team/dawlet-poc/commit/d64a1b40bae8c64ad52b1ccc9387fc83fc75eea4))
* **utils:** resolve type errors by annotations ([668e2b1](https://github.com/dawlet-team/dawlet-poc/commit/668e2b13b06088d3c643138d0a32f168ef5e1539))
* **utils:** round midi note number ([2282b81](https://github.com/dawlet-team/dawlet-poc/commit/2282b8186a606b7525c4c145530d492f4ca2afae))


### Features

* **algolet:** add builder ([c8f954a](https://github.com/dawlet-team/dawlet-poc/commit/c8f954a172a9b3629ef3425d07350485cd42c6e5))
* **algolet:** add drag handler for main process ([2976e38](https://github.com/dawlet-team/dawlet-poc/commit/2976e38c6b7bdcc32eedcb3094249f83693f3bdb))
* **algolet:** add span method ([467904d](https://github.com/dawlet-team/dawlet-poc/commit/467904d52e7c8513f16684394e496b3d9df6a9be))
* **algolet:** apply offsets ([3a41fc0](https://github.com/dawlet-team/dawlet-poc/commit/3a41fc068bb67dc97fd22464bdbe1db191ea7e03))
* **algolet:** enable add pitch from top to down ([5caf7dd](https://github.com/dawlet-team/dawlet-poc/commit/5caf7ddbd93a69ef708078cd2eee5db117a24141))
* **algolet:** enable cloning ([85dcb57](https://github.com/dawlet-team/dawlet-poc/commit/85dcb571a3770dd93eb7da7ec51ad87fc473ac3a))
* **algolet:** enable dnd midi file ([cd8df17](https://github.com/dawlet-team/dawlet-poc/commit/cd8df17707715e01c76f8a48e5e953b4893c002c))
* **algolet:** enable reflecting octave in preview score ([592c655](https://github.com/dawlet-team/dawlet-poc/commit/592c65506eb9f697a7748ec1a9a3c7090f1809e7))
* **algolet:** enable repeat ([cee3590](https://github.com/dawlet-team/dawlet-poc/commit/cee3590e3a4ab21219250fd6447b1e52dc6f9f7e))
* **algolet:** enable showing score after eval ([a96db97](https://github.com/dawlet-team/dawlet-poc/commit/a96db97fdbb9ad4b412e8d38f2957ded1ef4e17f))
* **algolet:** flash after eval ([c6e6c0c](https://github.com/dawlet-team/dawlet-poc/commit/c6e6c0c1be12299bfe564e98300c11b3e9e8f22b))