### PR TITLE
Enable Notarization for macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,3 +40,5 @@ jobs:
           mac_csc_link: ${{ secrets.mac_certs }} 
           mac_csc_link_password: ${{ secrets.mac_certs_password }} 
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLEID: ${{ secrets.APPLEID }}
+          APPLEID_PASSWORD: ${{ secrets.APPLEID_PASSWORD }}

--- a/yogo/.gitignore
+++ b/yogo/.gitignore
@@ -1,3 +1,4 @@
+.envrc
 ### https://raw.github.com/github/gitignore/18654b47c86bef38add5cd091ec2dac7d6e6e37b/Node.gitignore
 
 lib/

--- a/yogo/.vscode/settings.json
+++ b/yogo/.vscode/settings.json
@@ -2,6 +2,7 @@
   "coverage-gutters.showGutterCoverage": false,
   "coverage-gutters.showLineCoverage": true,
   "cSpell.words": [
+    "APPLEID",
     "algo",
     "ftom",
     "mtrk",

--- a/yogo/dawlets/algolet/build/entitlements.mac.plist
+++ b/yogo/dawlets/algolet/build/entitlements.mac.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+  </dict>
+</plist>

--- a/yogo/dawlets/algolet/package-lock.json
+++ b/yogo/dawlets/algolet/package-lock.json
@@ -2271,6 +2271,16 @@
 			"dev": true,
 			"optional": true
 		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
 		"bluebird": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -3687,6 +3697,16 @@
 			"resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.2.4.tgz",
 			"integrity": "sha512-CXbDU+Iwi+TjKzugKZmTRIORIPe3uQRqgChUl19fkW/reFUn5WP7dt+cNGT3bkLV8xfPilpkPFv33HgtmLLewQ=="
 		},
+		"electron-notarize": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.0.0.tgz",
+			"integrity": "sha512-dsib1IAquMn0onCrNMJ6gtEIZn/azG8hZMCYOuZIMVMUeRMgBYHK1s5TK9P8xAcrAjh/2aN5WYHzgVSWX314og==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1",
+				"fs-extra": "^9.0.1"
+			}
+		},
 		"electron-publish": {
 			"version": "22.8.1",
 			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.8.1.tgz",
@@ -4323,6 +4343,13 @@
 				"loader-utils": "^2.0.0",
 				"schema-utils": "^2.7.1"
 			}
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true,
+			"optional": true
 		},
 		"filelist": {
 			"version": "1.0.1",
@@ -8002,6 +8029,13 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
+		"nan": {
+			"version": "2.14.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+			"dev": true,
+			"optional": true
+		},
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -11330,7 +11364,11 @@
 					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
 					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"bindings": "^1.5.0",
+						"nan": "^2.12.1"
+					}
 				},
 				"glob-parent": {
 					"version": "3.1.0",

--- a/yogo/dawlets/algolet/package.json
+++ b/yogo/dawlets/algolet/package.json
@@ -22,6 +22,7 @@
   "build": {
     "appId": "com.electron.algolet-beta",
     "productName": "Algolet@Beta",
+    "afterSign": "./scripts/notarize.js",
     "mac": {
       "hardenedRuntime": true,
       "gatekeeperAssess": false,

--- a/yogo/dawlets/algolet/package.json
+++ b/yogo/dawlets/algolet/package.json
@@ -23,6 +23,8 @@
     "appId": "com.electron.algolet-beta",
     "productName": "Algolet@Beta",
     "mac": {
+      "hardenedRuntime": true,
+      "entitlements": "./build/entitlements.mac.inherit.plist",
       "publish": {
         "provider": "github",
         "releaseType": "release"

--- a/yogo/dawlets/algolet/package.json
+++ b/yogo/dawlets/algolet/package.json
@@ -23,8 +23,10 @@
     "appId": "com.electron.algolet-beta",
     "productName": "Algolet@Beta",
     "mac": {
-      "hardenedRuntime": true,
-      "entitlements": "./build/entitlements.mac.inherit.plist",
+      "hardenedRuntime" : true,
+      "gatekeeperAssess": false,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
       "publish": {
         "provider": "github",
         "releaseType": "release"

--- a/yogo/dawlets/algolet/package.json
+++ b/yogo/dawlets/algolet/package.json
@@ -23,7 +23,7 @@
     "appId": "com.electron.algolet-beta",
     "productName": "Algolet@Beta",
     "mac": {
-      "hardenedRuntime" : true,
+      "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
@@ -65,6 +65,7 @@
     "css-loader": "4.3.0",
     "electron": "10.1.3",
     "electron-builder": "22.8.1",
+    "electron-notarize": "1.0.0",
     "file-loader": "6.1.0",
     "html-webpack-plugin": "4.5.0",
     "jest": "26.1.0",

--- a/yogo/dawlets/algolet/scripts/notarize.js
+++ b/yogo/dawlets/algolet/scripts/notarize.js
@@ -1,0 +1,25 @@
+const { notarize } = require('electron-notarize');
+const appBundleId = 'com.electron.algolet-beta'
+
+const appleId = process.env['APPLEID']
+const appleIdPassword = process.env['APPLEID_PASSWORD']
+exports.default = async function notarizing(context) {
+  const { electronPlatformName, appOutDir } = context;
+  if(!appleId) throw new Error('appleId is not set in the env')
+  if(!appleIdPassword) throw new Error('appleIdPassword is not set in the env')
+  if (electronPlatformName !== 'darwin') {
+    throw new Error(`Notarization failed. Expected platform is 'darwin' but you are on ${electronPlatformName}`)
+  }
+
+  const appName = context.packager.appInfo.productFilename;
+  const appPath = `${appOutDir}/${appName}.app`
+
+  console.log(`Notarizing ${appBundleId} found at ${appPath}`);
+
+  return await notarize({
+    appBundleId,
+    appPath,
+    appleId,
+    appleIdPassword
+  });
+};


### PR DESCRIPTION
Recently Apple changed their policy and now apparently there's something extra we have to do when distributing

# Refs

https://kilianvalkhof.com/2019/electron/notarizing-your-electron-application/
https://twitter-archive-eraser.medium.com/notarize-electron-apps-7a5f988406db
https://github.com/electron/electron-notarize
https://www.electron.build/configuration/mac