### PR TITLE
v0.9.2

### DIFF
--- a/yogo/CHANGELOG.md
+++ b/yogo/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.2](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.1...v0.9.2) (2021-04-17)
+
+
+### Bug Fixes
+
+* **algolet:** properly load midi icon for drag handler ([31ca44a](https://github.com/dawlet-team/dawlet-poc/commit/31ca44a251e56d1c6d58b86383e1fbddffd21919))
+* **algolet:** properly save tmp midi file ([c60fc19](https://github.com/dawlet-team/dawlet-poc/commit/c60fc19ece757b930dd9279752056dc4621c5b43))
+* prevent clean command from deleting lib folders in deps ([fe0cf5d](https://github.com/dawlet-team/dawlet-poc/commit/fe0cf5dd1f93a042f985fee59cb3408f8baae486))
+
+
+
+
+
 ## [0.9.1](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.0...v0.9.1) (2021-04-17)
 
 **Note:** Version bump only for package dawlet-poc

--- a/yogo/dawlets/algolet/CHANGELOG.md
+++ b/yogo/dawlets/algolet/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.2](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.1...v0.9.2) (2021-04-17)
+
+
+### Bug Fixes
+
+* **algolet:** properly load midi icon for drag handler ([31ca44a](https://github.com/dawlet-team/dawlet-poc/commit/31ca44a251e56d1c6d58b86383e1fbddffd21919))
+* **algolet:** properly save tmp midi file ([c60fc19](https://github.com/dawlet-team/dawlet-poc/commit/c60fc19ece757b930dd9279752056dc4621c5b43))
+
+
+
+
+
 ## [0.9.1](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.0...v0.9.1) (2021-04-17)
 
 **Note:** Version bump only for package @dawlet/algolet

--- a/yogo/dawlets/algolet/package-lock.json
+++ b/yogo/dawlets/algolet/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dawlet/algolet",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/yogo/dawlets/algolet/package.json
+++ b/yogo/dawlets/algolet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawlet/algolet",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "license": "MIT",
   "author": "Yuichi Yogo",
@@ -45,9 +45,9 @@
   },
   "description": "Algolet lets you write your own custom logic to generate music.",
   "dependencies": {
-    "@dawlet/graphql": "^0.9.1",
-    "@dawlet/ui": "^0.9.1",
-    "@dawlet/utils": "^0.9.1",
+    "@dawlet/graphql": "^0.9.2",
+    "@dawlet/ui": "^0.9.2",
+    "@dawlet/utils": "^0.9.2",
     "apollo-boost": "0.4.9",
     "electron-log": "4.2.4",
     "electron-updater": "4.3.5",

--- a/yogo/dawlets/launcher/CHANGELOG.md
+++ b/yogo/dawlets/launcher/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.2](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.1...v0.9.2) (2021-04-17)
+
+**Note:** Version bump only for package @dawlet/launcher
+
+
+
+
+
 ## [0.9.1](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.0...v0.9.1) (2021-04-17)
 
 **Note:** Version bump only for package @dawlet/launcher

--- a/yogo/dawlets/launcher/package-lock.json
+++ b/yogo/dawlets/launcher/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dawlet/launcher",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/yogo/dawlets/launcher/package.json
+++ b/yogo/dawlets/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawlet/launcher",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "license": "MIT",
   "author": "Yuichi Yogo",
@@ -16,8 +16,8 @@
     "watch:renderer": "webpack --mode=development --watch"
   },
   "dependencies": {
-    "@dawlet/engine": "^0.9.1",
-    "@dawlet/utils": "^0.9.1",
+    "@dawlet/engine": "^0.9.2",
+    "@dawlet/utils": "^0.9.2",
     "@material-ui/core": "4.11.0",
     "electron-log": "4.2.4",
     "electron-updater": "4.3.5",

--- a/yogo/dawlets/synthlet/CHANGELOG.md
+++ b/yogo/dawlets/synthlet/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.2](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.1...v0.9.2) (2021-04-17)
+
+**Note:** Version bump only for package @dawlet/synthlet
+
+
+
+
+
 ## [0.9.1](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.0...v0.9.1) (2021-04-17)
 
 **Note:** Version bump only for package @dawlet/synthlet

--- a/yogo/dawlets/synthlet/package-lock.json
+++ b/yogo/dawlets/synthlet/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dawlet/synthlet",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/yogo/dawlets/synthlet/package.json
+++ b/yogo/dawlets/synthlet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawlet/synthlet",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "license": "MIT",
   "author": "Yuichi Yogo",
@@ -16,7 +16,7 @@
   },
   "description": "Synthlet provides a simple synthesizer to playback the music. It has a dedicated local transport on its own. ",
   "dependencies": {
-    "@dawlet/utils": "^0.9.1",
+    "@dawlet/utils": "^0.9.2",
     "apollo-boost": "0.4.9",
     "apollo-link-ws": "1.0.20",
     "electron-log": "4.2.4",

--- a/yogo/lerna.json
+++ b/yogo/lerna.json
@@ -3,5 +3,5 @@
     "dawlets/*",
     "packages/*"
   ],
-  "version": "0.9.1"
+  "version": "0.9.2"
 }

--- a/yogo/packages/engine/CHANGELOG.md
+++ b/yogo/packages/engine/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.2](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.1...v0.9.2) (2021-04-17)
+
+**Note:** Version bump only for package @dawlet/engine
+
+
+
+
+
 ## [0.9.1](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.0...v0.9.1) (2021-04-17)
 
 **Note:** Version bump only for package @dawlet/engine

--- a/yogo/packages/engine/package-lock.json
+++ b/yogo/packages/engine/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dawlet/engine",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/yogo/packages/engine/package.json
+++ b/yogo/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawlet/engine",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "license": "MIT",
   "author": "Yuichi Yogo",
@@ -15,7 +15,7 @@
     "generate:docs": "graphdoc -s ./schema.gql -o ../../docs/schema"
   },
   "dependencies": {
-    "@dawlet/factory": "^0.9.1",
+    "@dawlet/factory": "^0.9.2",
     "@types/graphql": "14.5.0",
     "apollo-server": "2.18.0",
     "graphql": "14.7.0",

--- a/yogo/packages/factory/CHANGELOG.md
+++ b/yogo/packages/factory/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.2](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.1...v0.9.2) (2021-04-17)
+
+**Note:** Version bump only for package @dawlet/factory
+
+
+
+
+
 ## [0.9.1](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.0...v0.9.1) (2021-04-17)
 
 **Note:** Version bump only for package @dawlet/factory

--- a/yogo/packages/factory/package-lock.json
+++ b/yogo/packages/factory/package-lock.json
@@ -1,6 +1,6 @@
 {
       "name": "@dawlet/factory",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "lockfileVersion": 1,
       "requires": true,
       "dependencies": {

--- a/yogo/packages/factory/package.json
+++ b/yogo/packages/factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawlet/factory",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Factory for Dawlet Entities",
   "main": "lib/index.js",
   "scripts": {

--- a/yogo/packages/graphql/CHANGELOG.md
+++ b/yogo/packages/graphql/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.2](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.1...v0.9.2) (2021-04-17)
+
+**Note:** Version bump only for package @dawlet/graphql
+
+
+
+
+
 ## [0.9.1](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.0...v0.9.1) (2021-04-17)
 
 **Note:** Version bump only for package @dawlet/graphql

--- a/yogo/packages/graphql/package-lock.json
+++ b/yogo/packages/graphql/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dawlet/graphql",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/yogo/packages/graphql/package.json
+++ b/yogo/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawlet/graphql",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/yogo/packages/ui/CHANGELOG.md
+++ b/yogo/packages/ui/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.2](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.1...v0.9.2) (2021-04-17)
+
+**Note:** Version bump only for package @dawlet/ui
+
+
+
+
+
 ## [0.9.1](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.0...v0.9.1) (2021-04-17)
 
 **Note:** Version bump only for package @dawlet/ui

--- a/yogo/packages/ui/package-lock.json
+++ b/yogo/packages/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dawlet/ui",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/yogo/packages/ui/package.json
+++ b/yogo/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawlet/ui",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "license": "MIT",
   "author": "Yuichi Yogo",
@@ -16,7 +16,7 @@
     "storybook": "start-storybook -s ./public"
   },
   "dependencies": {
-    "@dawlet/utils": "^0.9.1",
+    "@dawlet/utils": "^0.9.2",
     "opensheetmusicdisplay": "0.8.4",
     "react": "16.13.1",
     "react-dom": "16.13.1"

--- a/yogo/packages/utils/CHANGELOG.md
+++ b/yogo/packages/utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.2](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.1...v0.9.2) (2021-04-17)
+
+**Note:** Version bump only for package @dawlet/utils
+
+
+
+
+
 ## [0.9.1](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.0...v0.9.1) (2021-04-17)
 
 **Note:** Version bump only for package @dawlet/utils

--- a/yogo/packages/utils/package-lock.json
+++ b/yogo/packages/utils/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dawlet/utils",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/yogo/packages/utils/package.json
+++ b/yogo/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawlet/utils",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "license": "MIT",
   "author": "Yuichi Yogo",


### PR DESCRIPTION
## [0.9.2](https://github.com/dawlet-team/dawlet-poc/compare/v0.9.1...v0.9.2) (2021-04-17)


### Bug Fixes

* **algolet:** properly load midi icon for drag handler ([31ca44a](https://github.com/dawlet-team/dawlet-poc/commit/31ca44a251e56d1c6d58b86383e1fbddffd21919))
* **algolet:** properly save tmp midi file ([c60fc19](https://github.com/dawlet-team/dawlet-poc/commit/c60fc19ece757b930dd9279752056dc4621c5b43))
* prevent clean command from deleting lib folders in deps ([fe0cf5d](https://github.com/dawlet-team/dawlet-poc/commit/fe0cf5dd1f93a042f985fee59cb3408f8baae486))